### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to Civitai's vast collection of AI models, creators, and generated content. Browse, search, and discover AI models seamlessly through your favorite MCP-compatible AI assistant.
 
+<a href="https://glama.ai/mcp/servers/@Cicatriiz/civitai-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cicatriiz/civitai-mcp-server/badge" alt="Civitai Server MCP server" />
+</a>
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)


### PR DESCRIPTION
This PR adds a badge for the [Civitai MCP Server](https://glama.ai/mcp/servers/@Cicatriiz/civitai-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Cicatriiz/civitai-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cicatriiz/civitai-mcp-server/badge" alt="Civitai Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an HTML badge linking to the Civitai MCP server page on glama.ai in the README.
  * Minor whitespace cleanup at the end of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->